### PR TITLE
bug(BLAZ-19123): SQL provider changes are committed.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 - `#174483` - The issue with "Folders order is improper while downloading the root folder from the Navigation pane" has been fixed.
 
+- `#281523` - The issue with "Access control is not properly working in search operation" has been fixed.
+
 ### SQL Server DataBase File Provider
 
 #### New Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,14 +16,6 @@
 
 - `#151112`, `#152443` - Support has been provided for access control.
 
-## 18.1.42 (2020-04-01)
-
-### SQL Server DataBase File Provider
-
-#### Bug Fixes
-
-- `#281523` - The issue with "Access control is not properly working in search operation" has been fixed.
-
 ## 18.2.44 (2020-07-06)
 
 ### SQL Server DataBase File Provider

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,14 @@
 
 ### SQL Server DataBase File Provider
 
+#### Bug Fixes
+
+- `#281523` - The issue with "Access control is not properly working in search operation" has been fixed.
+
+## 18.2.44 (2020-07-06)
+
+### SQL Server DataBase File Provider
+
 #### New Features
 
 - `#151515` - Support has been provided for upload customization.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ### SQL Server DataBase File Provider
 
+#### Bug Fixes
+
+- `#174483` - The issue with "Folders order is improper while downloading the root folder from the Navigation pane" has been fixed.
+
+### SQL Server DataBase File Provider
+
 #### New Features
 
 - `#151112`, `#152443` - Support has been provided for access control.


### PR DESCRIPTION
### Bug description

  * File Selection is removed after opening any dialog in the File manager for performing any file operation.
 * Selected items are not id values in File manager instead name values are added.
 * Delete operation is not working
 * The search operation is not returning the CWD value so file operations are not working properly
 * File Manager path is not created based on path ids instead created with the name
 * Rename a file/folder in a subfolder/ nested folder to the root folder, the application stops.
 * Breadcrumb navigation application stops.
 * After cut copy paste selection is not maintained.
 * Right-clicking on a file or folder after selecting it, selection removed.
 * Delete a file/folder in a subfolder/ nested folder to the root folder, the application stops.
 
### Root cause

  Since the Id based handling is not included in the File manager component, these issues occurred, I have now provided 
  changes for handling id-based services to resolve this issue.

### Solution description

  I have made changes to support for the Id based file provider services to make sure all the operations are working in the 
  Blazor file manager component.
 
### Reason for not identifying earlier

   * [ ]  Guidelines not followed. If yes, provide which guideline is not followed.
   * [ ]  Guidelines not given. If yes, provide which/who need to address.
           Tag label `update-guideline-coreteam` or `update-guideline-productteam`.
   * [x]  If any other reason, provide the details here - Since id service handling is not provided in the File manager component, 
            these issues occur.
 
#### Areas tested against this fix

  Provide details about the areas or combinations that have been tested against this code changes.

   * [x]   Tested against feature matrix. [Feature matrix link](https://github.com/essential-studio/ej2-file-manager-team-blazor-nunit/tree/development/Samples/RangeSlider)

### Is it a breaking issue?
   * [ ]   Yes, Tag `breaking-issue`.
   * [x]   NO

 If yes, provide the breaking commit details / MR here.

### Action taken

  We have fixed all the issue in the SQL file service provider in the Blazor File manager component
 
Feature matrix document updated
 
   * [ ]   Yes
   * [ ]   NO
   * [x]   NA

 Automation details - Mark `Is Automated` field as (Yes, Manual, Not Applicable) in corresponding JIRA task once the bug is automated.

   * [ ]  BUnit, share corresponding MR.
   * [x]  E2E or Manual Automation using tester - Make sure all items are automated with priority before release which can be tracked in automation dashboard.
 
If the same issue is reproduced in ej2, what will you do?
 
   * [ ]   Resolved. Provide MR link.
   * [ ]   NO. Created task to track it. Share task link.
   * [x]   NA
 
 Is this common issue need to be addressed in the same component or on other components in our platform?
 
   * [ ]   Yes - Need to check in other components, tag `needs-attention-coreteam`
   * [x]   No
 
### Output screenshots

 NA

### Blazor Checklist
  Confirm whether this feature is ensured in both Blazor Server and WASM
 
   * [ ]   NA
   * [x]   Yes
   * [ ]   NO

 Is there any new API or existing API name change?
 
   * [ ]   Yes. If yes, Provide API Review task link.
   * [x]   NO

 Is there any existing behavior change due to this code change?
 
   * [ ]   Yes. Add `breaking-change` label.
   * [x]   NO
 
 Do the code changes cause any memory leak and performance issue? (Test only if you suspect that your code may cause problem)
 
   * [ ]   Yes
   * [x]   NO
 
## Reviewer Checklist
   * [ ]   All provided information are reviewed and ensured.










































































