### PR TITLE
899760: Issue with drag and drop action in Navigation Pane in the File Manager component.

### DIFF
--- a/Models/SQLFileProvider.cs
+++ b/Models/SQLFileProvider.cs
@@ -126,11 +126,6 @@ namespace Syncfusion.EJ2.FileManager.Base.SQLFileProvider
                             SqlDataReader reader = command.ExecuteReader();
                             while (reader.Read())
                             {
-                                bool hasChild = false;
-                                if (!(bool)reader["IsFile"]) // Only check for directories
-                                {
-                                    hasChild = CheckIfHasChild(reader["ItemID"].ToString());
-                                }
                                 cwd = new FileManagerDirectoryContent
                                 {
                                     Name = reader["Name"].ToString().Trim(),
@@ -141,7 +136,7 @@ namespace Syncfusion.EJ2.FileManager.Base.SQLFileProvider
                                     DateCreated = (DateTime)reader["DateCreated"],
                                     Type = GetDefaultExtension(reader["MimeType"].ToString()),
                                     Id = reader["ItemID"].ToString(),
-                                    HasChild = hasChild,
+                                    HasChild = CheckIfHasChild(reader["ItemID"].ToString()),
                                     ParentID = reader["ParentID"].ToString(),
                                 };
                                 string sanitizedName = SanitizeFileName(cwd.Name);
@@ -163,11 +158,6 @@ namespace Syncfusion.EJ2.FileManager.Base.SQLFileProvider
                         SqlDataReader reader = command.ExecuteReader();
                         while (reader.Read())
                         {
-                            bool hasChild = false;
-                            if (!(bool)reader["IsFile"]) // Only check for directories
-                            {
-                                hasChild = CheckIfHasChild(reader["ItemID"].ToString());
-                            }
                             var childFiles = new FileManagerDirectoryContent
                             {
                                 Name = reader["Name"].ToString().Trim(),
@@ -175,7 +165,7 @@ namespace Syncfusion.EJ2.FileManager.Base.SQLFileProvider
                                 IsFile = (bool)reader["IsFile"],
                                 DateModified = (DateTime)reader["DateModified"],
                                 DateCreated = (DateTime)reader["DateCreated"],
-                                HasChild = hasChild,
+                                HasChild = CheckIfHasChild(reader["ItemID"].ToString()),
                                 Type = GetDefaultExtension(reader["MimeType"].ToString()),
                                 Id = reader["ItemID"].ToString(),
                                 ParentID = reader["ParentID"].ToString(),


### PR DESCRIPTION
### Bug description

Issue with drag and drop action in Navigation Pane in the File Manager component.

### Root cause

**Service Changes:**

The HasChild property value of the parent folder is not updated dynamically based on the drag and drop action in the SQL provider. As a result, it returns incorrect values, causing the mentioned issue to occur.

**Source Changes:**

When we perform the drag and drop action, the layout onPathChanged method is not triggered for ID-based providers. Therefore, the changes are not reflected in the details and large icons views.

### Solution description

**Service Changes:**

To resolve this issue, the HasChild value was updated based on the IsFile value. For parent folders, the CheckIfHasChild method was implemented in the server's GetFiles method to update the HasChild value properly.

**Source Changes:**

To address the issue where the layout did not refresh properly after performing a drag-and-drop action, the onPathChanged method was called based on the ID-based provider to refresh the layouts.



### Reason for not identifying earlier
 * [x] Guidelines not followed. If yes, provide which guideline is not followed.

 * [ ] Guidelines not given. If yes, provide which/who need to address.
    Tag label `update-guideline-coreteam` or `update-guideline-productteam`. 

 * [ ] If any other reason, provide the details here. 
     
ID providers with drag and drop action case was missed to check at our end. 

### Areas tested against this fix
Provide details about the areas or combinations that have been tested against this code changes.
* [ ]  Tested against feature matrix. [Feature matrix link](https://syncfusion.sharepoint.com/sites/EJ2ProductOwners/Shared%20Documents/Forms/AllItems.aspx?viewid=ae81c682%2D3d0f%2D462a%2Db8ec%2D7358748d489d&id=%2Fsites%2FEJ2ProductOwners%2FShared%20Documents%2FGeneral%2FFeature%20Matrix%20%2D%20Documents)
* [x]  NA

### Is it a breaking issue?
* [ ]  Yes, Tag `breaking-issue`. 
* [x]  NO
 
 If yes, provide the breaking commit details / MR here. 
 
### Action taken
What action did you take to avoid this in future?
Checked the basic cases.
 Feature matrix document updated
* [ ]  Yes
* [ ]  NO
* [x]  NA
 
Automation details - Mark `Is Automated` field as (Yes, Manual, Not Applicable) in corresponding JIRA task once the bug is automated. 
* [ ] BUnit, share corresponding MR.
* [ ] E2E or Manual Automation using tester - Make sure all items are automated with priority before release which can be tracked in [automation dashboard](https://syncfusion.atlassian.net/secure/Dashboard.jspa?selectPageId=43396).
 
If the same issue is reproduced in ej2, what will you do?
* [ ]  Resolved. Provide MR link.
* [ ]  NO. Created task to track it. Share task link. 
* [x]  NA
 
 Is this common issue need to be addressed in the same component or on other components in our platform? 
* [ ]  Yes - Need to check in other components, tag `needs-attention-coreteam` 
* [x]  No
  
### Output screenshots

NA

### Blazor Checklist
Confirm whether this feature is ensured in both Blazor Server and WASM
* [ ]  NA
* [x]  Yes
* [ ]  NO

Is there any new API or existing API name change?
* [ ]  Yes. If yes, Provide API Review task link.
* [x]  NO
  
Is there any existing behavior change due to this code change?
* [ ]  Yes. Add `breaking-change` label.
* [x]  NO


Do the code changes cause any memory leak and performance issue? (Test only if you suspect that your code may cause problem)
* [ ]  Yes
* [x]  NO

### Reviewer Checklist
* [ ]  All provided information are reviewed and ensured.