### PR TITLE
71570: Resolve the copy and paste issue in SQL service provider.

### DIFF
--- a/Models/SQLFileProvider.cs
+++ b/Models/SQLFileProvider.cs
@@ -1583,13 +1583,21 @@ namespace Syncfusion.EJ2.FileManager.Base.SQLFileProvider
                         string lastId = "";
                         string copyQuery = @"
                             INSERT INTO " + tableName + @" (Name, ParentID, Size, isFile, MimeType, Content, DateModified, DateCreated, HasChild, IsRoot, Type, FilterPath)
+                            OUTPUT INSERTED.ItemID
                             SELECT Name, @TargetId, Size, isFile, MimeType, Content, DateModified, DateCreated, HasChild, IsRoot, Type, FilterPath
                             FROM " + tableName + @" WHERE ItemID = @ItemId";
                         SqlCommand copyQuerycommand = new SqlCommand(copyQuery, sqlConnection);
                         copyQuerycommand.Parameters.AddWithValue("@TargetId", targetData.Id);
                         copyQuerycommand.Parameters.AddWithValue("@ItemId", item.Id);
-                        copyQuerycommand.ExecuteNonQuery();
-                        lastId = GetLastInsertedValue();
+                        object result = copyQuerycommand.ExecuteScalar();
+                        if (result != null)
+                        {
+                            lastId = result.ToString();
+                        }
+                        else
+                        {
+                            throw new Exception("Failed to retrieve the last inserted ID.");
+                        }
                         sqlConnection.Close();
                         sqlConnection.Open();
                         string query = "SELECT * FROM " + this.tableName + " WHERE ItemID = @LastId";


### PR DESCRIPTION
**Description:**
1. In sql sample, not able to perform copy paste operations.

**Solution**
1. The issue occurs due to the lastId is fetched immediately after the ExecuteNonQuery(). Resolved the issue by modifying INSERT statement to include an OUTPUT that returns the ItemID of the newly inserted record.