### PR TITLE
978456: File/Folder rename issue with the dot value in the FileManager component.

### DIFF
--- a/Controllers/SQLProviderController.cs
+++ b/Controllers/SQLProviderController.cs
@@ -75,7 +75,7 @@ namespace EJ2APIServices.Controllers
                     return operation.ToCamelCase(operation.Search(args.Path, args.SearchString, args.ShowHiddenItems, args.CaseSensitive, args.Data));
                 case "rename":
                     // Renames a file or folder.
-                    return operation.ToCamelCase(operation.Rename(args.Path, args.Name, args.NewName, false, args.Data));
+                    return operation.ToCamelCase(operation.Rename(args.Path, args.Name, args.NewName, false, args.ShowFileExtension, args.Data));
                 case "move":
                     // Cuts the selected file(s) or folder(s) from a path and then pastes them into a given target path.
                     return operation.ToCamelCase(operation.Move(args.Path, args.TargetPath, args.Names, args.RenameFiles, args.TargetData, args.Data));

--- a/Models/Base/FileManagerDirectoryContent.cs
+++ b/Models/Base/FileManagerDirectoryContent.cs
@@ -13,6 +13,8 @@ namespace Syncfusion.EJ2.FileManager.Base
 
         public string NewName { get; set; }
 
+        public bool ShowFileExtension { get; set; }
+
         public string[] RenameFiles { get; set; }
 
         public string TargetPath { get; set; }

--- a/Models/SQLFileProvider.cs
+++ b/Models/SQLFileProvider.cs
@@ -1291,6 +1291,15 @@ namespace Syncfusion.EJ2.FileManager.Base.SQLFileProvider
             FileManagerResponse renameResponse = new FileManagerResponse();
             try
             {
+                if (data == null || data.Length == 0 || data[0] == null)
+                {
+                    renameResponse.Error = new ErrorDetails
+                    {
+                        Code = "400",
+                        Message = "The file metadata (data[0]) is missing or not provided."
+                    };
+                    return renameResponse;
+                }
                 if (!showFileExtension && data[0].IsFile)
                 {
                     string extension = Path.GetExtension(data[0].Name);

--- a/Models/SQLFileProvider.cs
+++ b/Models/SQLFileProvider.cs
@@ -1286,11 +1286,20 @@ namespace Syncfusion.EJ2.FileManager.Base.SQLFileProvider
         }
 
         // Renames a file or folder
-        public FileManagerResponse Rename(string path, string name, string newName, bool replace = false, params FileManagerDirectoryContent[] data)
+        public FileManagerResponse Rename(string path, string name, string newName, bool replace = false, bool showFileExtension = true, params FileManagerDirectoryContent[] data)
         {
             FileManagerResponse renameResponse = new FileManagerResponse();
             try
             {
+                if (!showFileExtension && data[0].IsFile)
+                {
+                    string extension = Path.GetExtension(data[0].Name);
+                    if (!string.IsNullOrEmpty(extension))
+                    {
+                        name += extension;
+                        newName += extension;
+                    }
+                }
                 string sanitizedName = SanitizeFileName(data[0].Name);
                 AccessPermission permission = GetPermission(data[0].Id, data[0].ParentID, sanitizedName, data[0].IsFile, path);
                 if (permission != null && (!permission.Read || !permission.Write))


### PR DESCRIPTION
### Bug description

[Task-978456](https://dev.azure.com/EssentialStudio/Ej2-Web/_workitems/edit/978456):

**Issue 1**

When renaming a file in the Blazor FileManager using the SQL provider with ShowFileExtension="false", such as renaming 1.1 (a PNG/JPEG type file) to 1.1.6, the image preview becomes broken.

**Issue 2**

In the above scenario, after renaming, the UI displays the folder name as 1.1 instead of 1.1.6, due to the missing file extension during the rename process.

**Issue 3**

When renaming a folder that contains dots in its name (e.g., from 1.1.5 to 1.1.5.6), the final name shown in the UI becomes incorrect—it appears as 1.1.5.6.5.

**Issue 4**

When renaming a folder twice that contains dots in its name (e.g., 1.1.3), the rename dialog input field displays only 1.1 instead of the full current name.

### Root cause

**Issue 1:**

This issue occurred because, from the service side, the file names were coming without file extensions, which is why the reported issue occurred(for SQL and Azure providers).

**Issue 2:**

This issue occurred because we were removing the last value after the dot in the folder names using this line for the Large Icons view:

`fileName.Substring(0, fileName.LastIndexOf("."))`

...and using this line for Details view:

`text.Substring(0, text.LastIndexOf('.'))`


**Issue 3:**

This issue occurred because when a folder name contains dot (.) values, the portion after the last dot was mistakenly considered as its type(it occurs when renaming a second time for folders containing dot values(server-side issue)).

**Issue 4:**

When renaming a folder (e.g., 1.1.3) and then renaming it again causes it to display incorrectly (1.1). This happens because of the following line in the source:

`name.Substring(0, name.LastIndexOf("."))`


### Solution description

**Issue 1:**

To resolve this issue, we appended extension values only for files when ShowFileExtension="false" in the Rename method(server side).

**Issue 2:**

To resolve this, we ignored this logic for folders based on the isFile value for both views in the FileManager component. 

**Issue 3:**

To resolve this issue, the service provider, the file extension was appended only for files, not for folders.

**Issue 4:**

To resolve this issue, we ignored this logic for folders based on the isFile value.

### Impact assessment
* [x] Low - Affects a single feature with minimal user impact
* [ ] Medium - Affects multiple features or has moderate user impact
* [ ] High - Critical functionality or significant user impact
 
### Reason for not identifying earlier

Previously, this scenario was not tested properly.
     
### Areas tested against this fix

- [x] Ensured that creating a new folder with the name `1` and renaming it to `1.1` and then `1.1.6` displays the name correctly with proper dots in the FileManager component.

- [x] Ensured that renaming a file to `1.1` and then `1.1.6` reflects the updated name with proper dots in the FileManager component without any issues.

- [x] Ensured that the same rename scenarios work correctly with existing files and folders (e.g., named `character`), renamed to `1.1` and `1.1.6`, with the updated names displayed properly.

- [x] Ensured that uploaded files (e.g., `1.1.5`) renamed to `1.1` and `1.1.6` are displayed correctly with proper dots in the FileManager component.

- [x] Verified that all the above scenarios work properly with file operations: cut, copy, paste, delete, download, details, and drag-and-drop, without any issues.

- [x] Ensured the above scenarios with `ShowFileExtension="false"` and `AllowDragAndDrop=true`.
- [x] Ensured the above scenarios with `ShowFileExtension="true"` and `AllowDragAndDrop=true`.
- [x] Ensured the above scenarios with `ShowFileExtension="false"` and `AllowDragAndDrop=false`.
- [x] Ensured the above scenarios with `ShowFileExtension="true"` and `AllowDragAndDrop=false`.

- [x] Ensured that all the above scenarios were tested on the following providers: **Physical, SQL, Azure, and Amazon**.

- [x] Verified the above scenarios in both **Large Icons view** and **Details view** of the Blazor FileManager component.

### Breaking changes
* [ ] Yes (Tag `breaking-issue`)
* [x] No

### Regression testing
* [x] Verified fix doesn't reintroduce previous bugs
* [x] Checked edge cases and error scenarios

### Action taken to prevent recurrence
* [ ] Added/updated unit tests
* [x] Other (specify): Automation testing work assigned to the testing team to avoid this in the future.
* [ ] NA

### Automation status
* [x] BUnit (Assigned to testing team)
* [ ] Playwight (provide PR link: _________________)
* [ ] NA

### Cross-platform verification
* [x] Blazor Server
* [x] Blazor WASM
* [ ] NA
 
### Related issues
Is this issue present in EJ2 or other components?
* [ ] Resolved in EJ2 (PR link: _________________)
* [ ] Created task for EJ2 (Task link: _________________)
* [ ] Needs attention in other components (tag `needs-attention-coreteam`)
* [x] NA

### Output screenshots

Check this PR for screenshots: 

https://gitea.syncfusion.com/essential-studio/ej2-blazor-source/pulls/25323

### API changes
* [ ] New API added (API Review task link: _________________)
* [ ] Existing API renamed/modified (API Review task link: _________________)
* [x] No API changes

### Performance verification
* [x] Verified no memory leaks introduced
* [x] Verified no performance degradation
* [ ] Not applicable

### Reviewer Checklist
* [x] Code changes follow component guidelines
* [x] All provided information reviewed and verified
* [x] Solution addresses the root cause effectively